### PR TITLE
Missing file

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
    <file name="config.m4" role="src" />
    <file name="config.w32" role="src" />
    <file name="var_representation.c" role="src" />
+   <file name="var_representation.stub.php" role="src" />
    <file name="var_representation_arginfo.h" role="src" />
    <file name="php_var_representation.h" role="src" />
    <file name="README.md" role="doc" />
@@ -46,7 +47,7 @@
     <min>7.4.0</min>
    </php>
    <pearinstaller>
-    <min>1.4.0b1</min>
+    <min>1.10</min>
    </pearinstaller>
   </required>
  </dependencies>


### PR DESCRIPTION
Despite this file is not mandatory to build the ext, it is part of the project sources, and may be required for downstream (if patch need to be applied on this file)

Minimum pear version is the one with PHP 7 support.