### PR TITLE
Add VAR_REPRESENTATION_UNESCAPED flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,8 @@ jobs:
            PHP_VERSION_FULL: 7.4.20
          - PHP_VERSION: '8.0'
            PHP_VERSION_FULL: 8.0.7
-         - PHP_VERSION: '8.1.0alpha1'
-           PHP_VERSION_FULL: 8.1.0alpha1
+         - PHP_VERSION: '8.1.0beta2'
+           PHP_VERSION_FULL: 8.1.0beta2
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/README.md
+++ b/README.md
@@ -33,16 +33,30 @@ php > echo var_representation(['a','b']);
   'a',
   'b',
 ]
+
 // can dump everything on one line.
 php > echo var_representation(['a', 'b', 'c'], VAR_REPRESENTATION_SINGLE_LINE);
 ['a', 'b', 'c']
+
 php > echo var_representation("uses double quotes: \$\"'\\\n");
 "uses double quotes: \$\"'\\\n"
+
+// Can disable the escaping of control characters
+// (e.g. if the return value needs to be escaped again)
+php > echo var_representation("has\nnewlines", VAR_REPRESENTATION_UNESCAPED);
+'has
+newlines'
+php > echo json_encode("uses single quotes:\0\r\n\$\"'\\");
+"uses single quotes:\u0000\r\n$\"'\\"
+php > echo json_encode(var_representation("uses single quotes:\0\r\n\$\"'\\",
+                                          VAR_REPRESENTATION_UNESCAPED));
+"'uses single quotes:\u0000\r\n$\"\\'\\\\'"
 ```
 
 ## Documentation
 
 Refer to https://wiki.php.net/rfc/readable_var_representation for details such as what characters are escaped.
+Also see the section [Differences from `var_export`](#differences-from-var_export).
 
 ## Background information
 
@@ -76,3 +90,9 @@ Proposals to add alternatives better to var_export to php itself
   optional parameter `int $flags = 0` accepting a bitmask. If the
   value of $flags includes this flags, `var_representation()` will
   return a single-line representation for arrays/objects.
+- Support the bit flag `VAR_REPRESENTATION_UNESCAPED` to force
+  strings to be single quoted and avoid escaping any control characters other than `'` and `\`
+  (e.g. newlines will not be escaped even with VAR_REPRESENTATION_SINGLE_LINE).
+
+  This may be useful when short representations are needed,
+  or if the return value is escaped again.

--- a/ci/install_php_custom.sh
+++ b/ci/install_php_custom.sh
@@ -31,12 +31,16 @@ if [ "x${TRAVIS:-0}" != "x" ]; then
 fi
 
 # Otherwise, put a minimal installation inside of the cache.
-PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
+if [ "$PHP_CUSTOM_NORMAL_VERSION" == "8.1.0" ] ; then
+	PHP_CUSTOM_VERSION=8.1.0beta2
+	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
 
-PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-if [[ $PHP_CUSTOM_NORMAL_VERSION == 8.1.0 ]]; then
-	PHP_TAR_URL=https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.bz2
+	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
+	PHP_TAR_URL=https://downloads.php.net/~ramsey/$PHP_TAR_FILE
 else
+	PHP_FOLDER="php-$PHP_CUSTOM_VERSION"
+
+	PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
 	PHP_TAR_URL=https://secure.php.net/distributions/$PHP_TAR_FILE
 fi
 if [ ! -f $PHP_TAR_FILE ]; then

--- a/ci/run-tests-parallel.php
+++ b/ci/run-tests-parallel.php
@@ -693,7 +693,7 @@ function main()
         $environment['TEST_PHP_EXECUTABLE'] = $php;
     }
 
-    if (strlen($conf_passed)) {
+    if ($conf_passed !== null) {
         if (IS_WINDOWS) {
             $pass_options .= " -c " . escapeshellarg($conf_passed);
         } else {

--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2021-06-26</date>
+ <date>2021-08-14</date>
  <time>16:00:00</time>
  <version>
-  <release>0.1.1dev</release>
-  <api>0.1.1dev</api>
+  <release>0.1.1</release>
+  <api>0.1.1</api>
  </version>
  <stability>
   <release>stable</release>
@@ -23,6 +23,9 @@
  <license uri="https://github.com/TysonAndre/var_representation/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
 * Optimize escaping single quoted strings
+* Add a new flag VAR_REPRESENTATION_UNESCAPED to always encode strings as single quoted strings without escaping control characters.
+  This may be useful when the result of var_representation is escaped again before being rendered (e.g. json encoding),
+  or when a short representation is desired.
  </notes>
  <contents>
   <dir name="/">
@@ -42,6 +45,7 @@
     <file name="003.phpt" role="test" />
     <file name="004.phpt" role="test" />
     <file name="005.phpt" role="test" />
+    <file name="006.phpt" role="test" />
     <file name="dump.inc" role="test" />
     <file name="php81.phpt" role="test" />
    </dir>

--- a/php_var_representation.h
+++ b/php_var_representation.h
@@ -16,7 +16,7 @@ extern zend_module_entry var_representation_module_entry;
 
 PHP_MINIT_FUNCTION(var_representation);
 
-# define PHP_VAR_REPRESENTATION_VERSION "0.1.1dev"
+# define PHP_VAR_REPRESENTATION_VERSION "0.1.1"
 
 # if defined(ZTS) && defined(COMPILE_DL_VAR_REPRESENTATION)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/tests/006.phpt
+++ b/tests/006.phpt
@@ -1,0 +1,87 @@
+--TEST--
+Test var_representation() function with VAR_REPRESENTATION_UNESCAPED
+--FILE--
+<?php
+function dump($value): void {
+    // VAR_REPRESENTATION_UNESCAPED will always encode strings in single quotes for consistency,
+    // even when it contains single quotes.
+    $repr = var_representation(var_representation($value, VAR_REPRESENTATION_SINGLE_LINE | VAR_REPRESENTATION_UNESCAPED));
+    echo "oneline escaped twice: $repr\n";
+}
+dump(null);
+dump(false);
+dump(true);
+dump(0);
+dump(0.0);
+dump(new stdClass());
+dump((object)['key' => "\$value\tsecond"]);
+dump([]);
+dump([1,2,3]);
+dump(new ArrayObject(['a', ['b']]));
+dump("Content-Length: 42\r\n");
+// use octal
+dump(["Foo\0\r\n\r\001\x19test quotes and special characters\$b'\"\\" => "\0"]);
+// does not escape or check validity of bytes "\80-\ff" (e.g. utf-8 data)
+dump("▜");
+dump((object)["Foo\0\r\n\r\001" => true]);
+echo "STDIN is dumped as null, like var_export\n";
+dump(STDIN);
+echo "The ascii range is encoded as follows:\n";
+echo var_representation(implode('', array_map('chr', range(0, 0x7f)))), "\n";
+echo "Recursive objects cause a warning, like var_export\n";
+$x = new stdClass();
+$x->x = $x;
+dump($x);
+echo "Recursive arrays cause a warning, like var_export\n";
+
+$a = [];
+$a[0] = &$a;
+$a[1] = 'other';
+dump($a);
+$ref = 'ref shown as value like var_export';
+dump([(object)['key' => (object)['inner' => [1.0]], 'other' => &$ref]]);
+class Example {
+    public $untyped1;
+    public $untyped2 = null;
+    public $untyped3 = 3;
+    // rendering does not depend on existence of public function __set_state(), like var_export.
+}
+$x = new Example();
+unset($x->untyped1);  // unset properties/uninitialized typed properties are not shown, like var_export
+dump($x);
+dump("'");
+dump("\\\\\\\\\\\\");
+?>
+--EXPECTF--
+oneline escaped twice: 'null'
+oneline escaped twice: 'false'
+oneline escaped twice: 'true'
+oneline escaped twice: '0'
+oneline escaped twice: '0.0'
+oneline escaped twice: '(object) []'
+oneline escaped twice: "(object) ['key' => '\$value\tsecond']"
+oneline escaped twice: '[]'
+oneline escaped twice: '[1, 2, 3]'
+oneline escaped twice: '\\ArrayObject::__set_state([\'a\', [\'b\']])'
+oneline escaped twice: "'Content-Length: 42\r\n'"
+oneline escaped twice: "['Foo\x00\r\n\r\x01\x19test quotes and special characters\$b\\'\"\\\\' => '\x00']"
+oneline escaped twice: '\'▜\''
+oneline escaped twice: "(object) ['Foo\x00\r\n\r\x01' => true]"
+STDIN is dumped as null, like var_export
+
+Warning: var_representation does not handle resources in %s on line 5
+oneline escaped twice: 'null'
+The ascii range is encoded as follows:
+"\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#\$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f"
+Recursive objects cause a warning, like var_export
+
+Warning: var_representation does not handle circular references in %s on line 5
+oneline escaped twice: '(object) [\'x\' => null]'
+Recursive arrays cause a warning, like var_export
+
+Warning: var_representation does not handle circular references in %s on line 5
+oneline escaped twice: '[null, \'other\']'
+oneline escaped twice: '[(object) [\'key\' => (object) [\'inner\' => [1.0]], \'other\' => \'ref shown as value like var_export\']]'
+oneline escaped twice: '\\Example::__set_state([\'untyped2\' => null, \'untyped3\' => 3])'
+oneline escaped twice: '\'\\\'\''
+oneline escaped twice: '\'\\\\\\\\\\\\\\\\\\\\\\\\\''

--- a/var_representation.h
+++ b/var_representation.h
@@ -28,6 +28,7 @@ struct zval;
 #	define VAR_REPRESENTATION_API /* nothing special */
 #endif
 
+VAR_REPRESENTATION_API void var_representation_ex_flags(zval *struc, int level, int flags, smart_str *buf);
 VAR_REPRESENTATION_API void var_representation_ex(zval *struc, int level, smart_str *buf);
 
 #endif


### PR DESCRIPTION
When this flag is enabled, strings will be rendered as single quoted
values and control characters will not be escaped.

Closes #7