### PR TITLE
0.1.2: Check for infinite recursion on the object instance instead

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,22 +36,32 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.7
+                  PHP_VER: 8.1.9
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.7
+                  PHP_VER: 8.1.9
+                  TS: 0
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x86
+                  VC: vs16
+                  PHP_VER: 8.0.22
+                  TS: 1
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x64
+                  VC: vs16
+                  PHP_VER: 8.0.22
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.4.20
+                  PHP_VER: 7.4.30
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.4.20
+                  PHP_VER: 7.4.30
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
            PHP_VERSION_FULL: 8.0.22
          - PHP_VERSION: '8.1'
            PHP_VERSION_FULL: 8.1.9
-         - PHP_VERSION: '8.2.0beta2'
-           PHP_VERSION_FULL: 8.2.0beta2
+         - PHP_VERSION: '8.2.0beta3'
+           PHP_VERSION_FULL: 8.2.0beta3
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tags
 *~
 *.tgz
 *.dep
+.deps
 
 *.lo
 *.la

--- a/ci/run-tests-parallel.php
+++ b/ci/run-tests-parallel.php
@@ -2787,10 +2787,10 @@ case "$1" in
     gdb --args {$cmd}
     ;;
 "valgrind")
-    USE_ZEND_ALLOC=0 valgrind $2 ${cmd}
+    USE_ZEND_ALLOC=0 valgrind $2 {$cmd}
     ;;
 "rr")
-    rr record $2 ${cmd}
+    rr record $2 {$cmd}
     ;;
 *)
     {$cmd}

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2021-08-14</date>
+ <date>2022-08-30</date>
  <time>16:00:00</time>
  <version>
   <release>0.1.2</release>

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,8 @@
  <date>2021-08-14</date>
  <time>16:00:00</time>
  <version>
-  <release>0.1.2dev</release>
-  <api>0.1.2dev</api>
+  <release>0.1.2</release>
+  <api>0.1.2</api>
  </version>
  <stability>
   <release>stable</release>
@@ -22,7 +22,10 @@
  </stability>
  <license uri="https://github.com/TysonAndre/var_representation/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* TBD
+* Switch from infinite recursion detection on the object's properties to infinite recursion detection on the object itself.
+  This conforms with the change to var_export/debug_zval_dump in php 8.2-dev,
+  and would allow data structures to safely start returning temporary arrays that can be garbage collected to save memory
+  (after dumping the representation) starting in php 8.2+.
  </notes>
  <contents>
   <dir name="/">
@@ -43,6 +46,7 @@
     <file name="004.phpt" role="test" />
     <file name="005.phpt" role="test" />
     <file name="006.phpt" role="test" />
+    <file name="007.phpt" role="test" />
     <file name="dump.inc" role="test" />
     <file name="php81.phpt" role="test" />
    </dir>

--- a/php_var_representation.h
+++ b/php_var_representation.h
@@ -16,7 +16,7 @@ extern zend_module_entry var_representation_module_entry;
 
 PHP_MINIT_FUNCTION(var_representation);
 
-# define PHP_VAR_REPRESENTATION_VERSION "0.1.2dev"
+# define PHP_VAR_REPRESENTATION_VERSION "0.1.2"
 
 # if defined(ZTS) && defined(COMPILE_DL_VAR_REPRESENTATION)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,0 +1,23 @@
+--TEST--
+SplFixedArray: Infinite recursion detection edge cases
+--FILE--
+<?php
+call_user_func(function () {
+    $x = new SplFixedArray(4);
+    $x[0] = NAN;
+    $x[1] = 0.0;
+    $x[2] = $x;
+    $x[3] = $x;
+    echo var_representation($x), "\n";
+});
+?>
+--EXPECTF--
+Warning: var_representation does not handle circular references in %s on line 8
+
+Warning: var_representation does not handle circular references in %s on line 8
+\SplFixedArray::__set_state([
+  NAN,
+  0.0,
+  null,
+  null,
+])


### PR DESCRIPTION
Closes #9

Calling Z_OBJPROP_P in php 7.3+ may require data structures such as
SplFixedArray to populate the entire hash table and check for any
elements that were removed from the underlying data structure.

Imitiate the way var_export and debug_zval_dumpwas changed in php 8.2-dev

This would also make it safe for data structures to return temporary
arrays that would be garbage collected by the caller of
zend_get_properties_for. (starting in php 8.2)