### PR TITLE
Fix improper detection of VAR_REPRESENTATION_UNESCAPED flag.

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -10,7 +10,7 @@ ADD *.sh *.c *.h *.php *.md config.m4 config.w32 package.xml COPYING ./
 
 # Assume compilation will be the time consuming step.
 # Add tests after compiling so that it's faster to update tests and re-run them locally.
-RUN phpize && ./configure && make -j2 && make install
+RUN export CFLAGS='-O3 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter'; phpize && ./configure && make -j2 && make install
 RUN docker-php-ext-enable var_representation
 ADD tests ./tests
 ADD ci ./ci

--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-08-30</date>
+ <date>2022-10-14</date>
  <time>16:00:00</time>
  <version>
-  <release>0.1.2</release>
-  <api>0.1.2</api>
+  <release>0.1.3</release>
+  <api>0.1.3</api>
  </version>
  <stability>
   <release>stable</release>
@@ -22,10 +22,7 @@
  </stability>
  <license uri="https://github.com/TysonAndre/var_representation/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* Switch from infinite recursion detection on the object's properties to infinite recursion detection on the object itself.
-  This conforms with the change to var_export/debug_zval_dump in php 8.2-dev,
-  and would allow data structures to safely start returning temporary arrays that can be garbage collected to save memory
-  (after dumping the representation) starting in php 8.2+.
+* Fix improper detection of VAR_REPRESENTATION_UNESCAPED flag. The var_representation function was previously checking for VAR_REPRESENTATION_SINGLE_LINE due to missing parenthesis in a bitwise operation.
  </notes>
  <contents>
   <dir name="/">
@@ -65,6 +62,25 @@
  <providesextension>var_representation</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2022-08-30</date>
+   <time>16:00:00</time>
+   <version>
+    <release>0.1.2</release>
+    <api>0.1.2</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/TysonAndre/var_representation/blob/main/COPYING">BSD-3-Clause</license>
+   <notes>
+* Switch from infinite recursion detection on the object's properties to infinite recursion detection on the object itself.
+  This conforms with the change to var_export/debug_zval_dump in php 8.2-dev,
+  and would allow data structures to safely start returning temporary arrays that can be garbage collected to save memory
+  (after dumping the representation) starting in php 8.2+.
+   </notes>
+  </release>
   <release>
    <date>2021-08-14</date>
    <time>16:00:00</time>

--- a/php_var_representation.h
+++ b/php_var_representation.h
@@ -16,7 +16,7 @@ extern zend_module_entry var_representation_module_entry;
 
 PHP_MINIT_FUNCTION(var_representation);
 
-# define PHP_VAR_REPRESENTATION_VERSION "0.1.2"
+# define PHP_VAR_REPRESENTATION_VERSION "0.1.3"
 
 # if defined(ZTS) && defined(COMPILE_DL_VAR_REPRESENTATION)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/tests/006.phpt
+++ b/tests/006.phpt
@@ -2,11 +2,11 @@
 Test var_representation() function with VAR_REPRESENTATION_UNESCAPED
 --FILE--
 <?php
-function dump($value): void {
+function dump($value, int $innerFlags = VAR_REPRESENTATION_SINGLE_LINE | VAR_REPRESENTATION_UNESCAPED, string $description = 'oneline'): void {
     // VAR_REPRESENTATION_UNESCAPED will always encode strings in single quotes for consistency,
     // even when it contains single quotes.
-    $repr = var_representation(var_representation($value, VAR_REPRESENTATION_SINGLE_LINE | VAR_REPRESENTATION_UNESCAPED));
-    echo "oneline escaped twice: $repr\n";
+    $repr = var_representation(var_representation($value, $innerFlags));
+    echo "$description escaped twice: $repr\n";
 }
 dump(null);
 dump(false);
@@ -21,8 +21,14 @@ dump(new ArrayObject(['a', ['b']]));
 dump("Content-Length: 42\r\n");
 // use octal
 dump(["Foo\0\r\n\r\001\x19test quotes and special characters\$b'\"\\" => "\0"]);
+dump(["Foo\0\r\n\r\001\x19test quotes and special characters\$b'\"\\" => "\0"], VAR_REPRESENTATION_SINGLE_LINE, 'only oneline');
+dump(["Foo\0\r\n\r\001\x19test quotes and special characters\$b'\"\\" => "\0"], VAR_REPRESENTATION_UNESCAPED, 'only unescaped');
+dump(["Foo\0\r\n\r\001\x19test quotes and special characters\$b'\"\\" => "\0"], -1 & ~(VAR_REPRESENTATION_UNESCAPED|VAR_REPRESENTATION_SINGLE_LINE), 'only unrecognized');
 // does not escape or check validity of bytes "\80-\ff" (e.g. utf-8 data)
 dump("▜");
+dump("▜\n", VAR_REPRESENTATION_UNESCAPED, 'unescaped');
+dump("▜\n", VAR_REPRESENTATION_SINGLE_LINE, 'only oneline');
+dump("▜\n", 0, 'no flags');
 dump((object)["Foo\0\r\n\r\001" => true]);
 echo "STDIN is dumped as null, like var_export\n";
 dump(STDIN);
@@ -65,7 +71,13 @@ oneline escaped twice: '[1, 2, 3]'
 oneline escaped twice: '\\ArrayObject::__set_state([\'a\', [\'b\']])'
 oneline escaped twice: "'Content-Length: 42\r\n'"
 oneline escaped twice: "['Foo\x00\r\n\r\x01\x19test quotes and special characters\$b\\'\"\\\\' => '\x00']"
+only oneline escaped twice: '["Foo\\x00\\r\\n\\r\\x01\\x19test quotes and special characters\\$b\'\\"\\\\" => "\\x00"]'
+only unescaped escaped twice: "[\n  'Foo\x00\r\n\r\x01\x19test quotes and special characters\$b\\'\"\\\\' => '\x00',\n]"
+only unrecognized escaped twice: "[\n  \"Foo\\x00\\r\\n\\r\\x01\\x19test quotes and special characters\\\$b'\\\"\\\\\" => \"\\x00\",\n]"
 oneline escaped twice: '\'▜\''
+unescaped escaped twice: "'▜\n'"
+only oneline escaped twice: '"▜\\n"'
+no flags escaped twice: '"▜\\n"'
 oneline escaped twice: "(object) ['Foo\x00\r\n\r\x01' => true]"
 STDIN is dumped as null, like var_export
 

--- a/var_representation.c
+++ b/var_representation.c
@@ -259,7 +259,7 @@ static void var_representation_encode_array_element(zval *zv, zend_ulong index, 
 		var_representation_string(buf, ZSTR_VAL(key), ZSTR_LEN(key), unescaped);
 		smart_str_appendl(buf, " => ", 4);
 	}
-	var_representation_ex_flags(zv, multiline ? level + 2 : -1, unescaped, buf);
+	var_representation_ex_inner(zv, multiline ? level + 2 : -1, unescaped, buf);
 
 	if (multiline) {
 		smart_str_appendc(buf, ',');

--- a/var_representation.c
+++ b/var_representation.c
@@ -455,7 +455,7 @@ again:
 
 ZEND_COLD VAR_REPRESENTATION_API void var_representation_ex_flags(zval *struc, int level, int flags, smart_str *buf) /* {{{ */
 {
-	var_representation_ex_inner(struc, level, flags & VAR_REPRESENTATION_UNESCAPED != 0, buf);
+	var_representation_ex_inner(struc, level, (flags & VAR_REPRESENTATION_UNESCAPED) != 0, buf);
 }
 
 /* }}} */


### PR DESCRIPTION
The var_representation function was previously checking for VAR_REPRESENTATION_SINGLE_LINE due to missing parenthesis in a bitwise operation.

Noticed in #14 due to gcc's `-Wparenthesis` warning